### PR TITLE
Improved readability.

### DIFF
--- a/pages/docs/cr-sqlite/api-methods/crsql_db_version.mdx
+++ b/pages/docs/cr-sqlite/api-methods/crsql_db_version.mdx
@@ -1,6 +1,6 @@
 # crsql_db_version
 
-`crsql_db_version` returns the current lamport timestamp of the database. This value is incremented on every transaction made to the database and moved up to the `MAX(this_db_version, peer_db_version)` when syncing in order to allow causal ordering of changes between databases.
+`crsql_db_version` returns the current lamport timestamp of the database. This value is incremented on every transaction made to the database and moved up to the `MAX(this_db_version, peer_db_version)` when syncing, in order to allow causal ordering of changes between databases.
 
 ## Usage
 


### PR DESCRIPTION
"when syncing in order" could be misread, so a comma makes this much more readable.